### PR TITLE
Mongodb tools and database dump

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dump_2026-03-25/** filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ github_api/__pycache__
 !github_api/search_terms.json
 *.ct
 *.xml
+dump

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ lint: ## Uses black and isort to lint github_api
 	isort github_api/
 
 dump: ## Creats a mongodump of the database
-	mongodump --host=mongo:27017
+	mongodump --host=mongo:27017 --db=Vex
 
 restore: ## Restores the database from a mongodump
-	mongorestore --host=mongo:27017
+	mongorestore --host=mongo:27017 
 
 # Thanks to Andreas Bauer
 help: ## Show this help

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,13 @@ lint: ## Uses black and isort to lint github_api
 	isort github_api/
 
 dump: ## Creats a mongodump of the database
-	mongodump --host=mongo:27017 --db=Vex
+	mongodump --host=mongo:27017 --db=Vex --gzip
 
 restore: ## Restores the database from a mongodump
-	mongorestore --host=mongo:27017 
+	mongorestore --host=mongo:27017 --gzip
+
+restoreDump2026:
+	mongorestore --host=mongo:27017 --gzip ./dump_2026-03-25
 
 # Thanks to Andreas Bauer
 help: ## Show this help

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
-install: ## Install requirements
+installPython: ## Installs python packeges
 	pip install -r github_api/requirements.txt
+
+install: installPython installMongodbTools	## Install requirements
+
+installMongodbTools:	## Installs Mongodb tools
+	chmod +x install_MongoDB_Tools.sh
+	./install_MongoDB_Tools.sh
 
 run: ## This will create and start the containers for both the database and the main api script
 	docker-compose up

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ installPython: ## Installs python packeges
 install: installPython installMongodbTools	## Install requirements
 
 installMongodbTools:	## Installs Mongodb tools
-	chmod +x install_MongoDB_Tools.sh
+	sudo chmod +x install_MongoDB_Tools.sh
 	./install_MongoDB_Tools.sh
 
 run: ## This will create and start the containers for both the database and the main api script
@@ -13,6 +13,12 @@ run: ## This will create and start the containers for both the database and the 
 lint: ## Uses black and isort to lint github_api
 	python -m black github_api/
 	isort github_api/
+
+dump: ## Creats a mongodump of the database
+	mongodump --host=mongo:27017
+
+restore: ## Restores the database from a mongodump
+	mongorestore --host=mongo:27017
 
 # Thanks to Andreas Bauer
 help: ## Show this help

--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ It is recomended to use the dev container for isolation and to have all the help
 
 Most commands can be run with make, see the [make file](Makefile) or run `make help`:
 ```
+dump                           Creats a mongodump of the database
 help                           Show this help
 install                        Install requirements
+installMongodbTools            Installs Mongodb tools
+installPython                  Installs python packeges
+lint                           Uses black and isort to lint github_api
+restore                        Restores the database from a mongodump
+run                            This will create and start the containers for both the database and the main api script
 ```
 
 ### Prerequisites

--- a/dump_2026-03-25/Vex/CSAF.bson.gz
+++ b/dump_2026-03-25/Vex/CSAF.bson.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02fe11c4580774ead54bd380fa84f3d2101ecf472f1401b324dfbe6217c6e92b
+size 126674564

--- a/dump_2026-03-25/Vex/CSAF.metadata.json.gz
+++ b/dump_2026-03-25/Vex/CSAF.metadata.json.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fb9f60956a50d6bb0d2ef30cf476152dfdd6445f9ada8ad70b9756a5c9a5923
+size 153

--- a/dump_2026-03-25/Vex/CycloneDX.bson.gz
+++ b/dump_2026-03-25/Vex/CycloneDX.bson.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d84b3bcbcac507bf3f1e6d9117961434f3f5dae8bdcd792f4ba992a10a30c08
+size 12772578

--- a/dump_2026-03-25/Vex/CycloneDX.metadata.json.gz
+++ b/dump_2026-03-25/Vex/CycloneDX.metadata.json.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a5f8a2b2312c2b21df4bd0783084b0ddbe00cb4a7667050f26a1ad0cf5d3443
+size 155

--- a/dump_2026-03-25/Vex/OpenVEX.bson.gz
+++ b/dump_2026-03-25/Vex/OpenVEX.bson.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7955c3fe147a6fdc284eb360e4748e2e159324341607d62155560001d08ff013
+size 10594112

--- a/dump_2026-03-25/Vex/OpenVEX.metadata.json.gz
+++ b/dump_2026-03-25/Vex/OpenVEX.metadata.json.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d54c964037fe18fa9408459c352872695368a67be342c6b9ed2ad830fe46da38
+size 155

--- a/dump_2026-03-25/Vex/SPDX.bson.gz
+++ b/dump_2026-03-25/Vex/SPDX.bson.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:845795c201e3fd505cb8b3a3d042f46b26769a17d25efbdcb3003df5f684eca4
+size 194322

--- a/dump_2026-03-25/Vex/SPDX.metadata.json.gz
+++ b/dump_2026-03-25/Vex/SPDX.metadata.json.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:652031478ba48b112390fddd69ab3aaf23955605fdd32a7e3d656521ba990287
+size 153

--- a/dump_2026-03-25/Vex/prelude.json.gz
+++ b/dump_2026-03-25/Vex/prelude.json.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8a493c8506d0deb22a1bde04ffc83f3b4cf556791130c2c5056827a10e31652
+size 66

--- a/github_api/main.py
+++ b/github_api/main.py
@@ -252,7 +252,6 @@ def initial_search(search_terms: dict) -> tuple[dict[list], int]:
     """
     search_urls = construct_search_code_urls(search_terms)
     search_result = {}
-    total_count = 0
 
     for specification, searches in search_urls.items():
         search_result[specification] = []
@@ -261,7 +260,6 @@ def initial_search(search_terms: dict) -> tuple[dict[list], int]:
             content = request.json()
 
             if "total_count" in content.keys():
-                total_count += content["total_count"]
                 if content["total_count"] > GITHUB_SEARCH_LIMIT:
                     search_result = split_search(
                         search_result,
@@ -274,7 +272,12 @@ def initial_search(search_terms: dict) -> tuple[dict[list], int]:
                         {"search_url": url["search_url"], "request": deepcopy(request)}
                     )
 
-    return search_result, total_count
+    result_count = 0
+    for specification, searches in search_result.items():
+        for search in searches:
+            result_count += search["request"].json()["total_count"]
+    
+    return search_result, result_count
 
 
 def file_generator(pages: dict[list]) -> Generator[dict]:

--- a/install_MongoDB_Tools.sh
+++ b/install_MongoDB_Tools.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+URL="https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian12-x86_64-100.15.0.deb"
+DEST="/home/vscode/mongodb-database-tools-debian12-x86_64-100.15.0.deb"
+
+curl -L -o "$DEST" "$URL"
+sudo apt install "$DEST"


### PR DESCRIPTION
To be able to easily share the database we decided to use [MongoDump](https://www.mongodb.com/docs/database-tools/mongodump/) and [MongoRestore](https://www.mongodb.com/docs/database-tools/mongorestore/). This PR includes a script that automatically fetches and installs [Mongo Database Tools](https://www.mongodb.com/docs/database-tools/). It also adds several make commands to make it easier to use the tools. Lastly this PR also includes a dump of the database after it's complete run through on 2026-03-35. It took ca 6h 15 min for a full run consisting of ca 30 000 files