### PR TITLE
Remove our own search_terms.json

### DIFF
--- a/dump_2026-03-25/Vex/SPDX.bson.gz
+++ b/dump_2026-03-25/Vex/SPDX.bson.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:845795c201e3fd505cb8b3a3d042f46b26769a17d25efbdcb3003df5f684eca4
-size 194322
+oid sha256:f0a434ae9ebde01bb0504ed9aae092329237dd65fc23b4f5e175f3f57de70729
+size 193905


### PR DESCRIPTION
As a result of our search we found our own [search_jterms.json](https://github.com/fimbo4/PA1445-Group1/blob/main/github_api/search_terms.json). As this is not a VEX file we are removing it from the dataset. It was only present in the SPDX collection. 